### PR TITLE
Resolve #11 Uncaught TYPO3 Exception

### DIFF
--- a/Classes/Validation/RecaptchaValidator.php
+++ b/Classes/Validation/RecaptchaValidator.php
@@ -49,7 +49,7 @@ class RecaptchaValidator extends \TYPO3\CMS\Extbase\Validation\Validator\Abstrac
                         'error_recaptcha_' . $status['error'],
                         'recaptcha'
                     ),
-                    1447258047591
+                    258047591
                 );
             }
         }


### PR DESCRIPTION
TYPO3\CMS\Form\Service\TranslationService->translateFormElementError() expects integer not double