### PR TITLE
#14 Resolves uncaught exception when no error code translation is given

### DIFF
--- a/Classes/Validation/RecaptchaValidator.php
+++ b/Classes/Validation/RecaptchaValidator.php
@@ -44,21 +44,13 @@ class RecaptchaValidator extends \TYPO3\CMS\Extbase\Validation\Validator\Abstrac
             $status = $captcha->validateReCaptcha();
             
             if ($status == false || $status['error'] !== '') {
+                $errorText = $this->translateErrorMessage('error_recaptcha_' . $status['error'], 'recaptcha');
                 
-                $errorText = $this->translateErrorMessage(
-                    'error_recaptcha_' . $status['error'],
-                    'recaptcha'
-                );
-                
-                if(empty($errorText)){
+                if (empty($errorText)) {
                     $errorText = htmlspecialchars($status['error']);
                 }
                 
-                $this->addError(
-                    $errorText
-                   ,
-                    1519982125
-                );
+                $this->addError($errorText, 1519982125);
             }
         }
     }

--- a/Classes/Validation/RecaptchaValidator.php
+++ b/Classes/Validation/RecaptchaValidator.php
@@ -42,13 +42,21 @@ class RecaptchaValidator extends \TYPO3\CMS\Extbase\Validation\Validator\Abstrac
 
         if ($captcha !== null) {
             $status = $captcha->validateReCaptcha();
-
+            
             if ($status == false || $status['error'] !== '') {
+                
+                $errorText = $this->translateErrorMessage(
+                    'error_recaptcha_' . $status['error'],
+                    'recaptcha'
+                );
+                
+                if(empty($errorText)){
+                    $errorText = htmlspecialchars($status['error']);
+                }
+                
                 $this->addError(
-                    $this->translateErrorMessage(
-                        'error_recaptcha_' . $status['error'],
-                        'recaptcha'
-                    ),
+                    $errorText
+                   ,
                     1519982125
                 );
             }


### PR DESCRIPTION
The commit b8b71de resolves the bug partially. We get still a uncaught exception (Fatal Error: Method TYPO3\CMS\Extbase\Validation\Error::__toString()) when we have no translation for the received API error.