### PR TITLE
Remove ?hl=de from data-sitekey

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -4,14 +4,7 @@ plugin.tx_recaptcha {
     public_key.wrap.cObject = COA
     public_key.wrap.cObject {
         10 = TEXT
-        10.value = <div class="g-recaptcha" data-sitekey="|
-
-        20 = TEXT
-        20.value = ?hl={$plugin.tx_recaptcha.lang}
-        20.if.isTrue.value = {$plugin.tx_recaptcha.lang}
-
-        30 = TEXT
-        30.value = "></div>
+        10.value = <div class="g-recaptcha" data-sitekey="|"></div>
     }
 
     # look at https://www.google.com/recaptcha/admin to register a key for your server

--- a/Resources/Private/Frontend/Partials/Form/Navigation.html
+++ b/Resources/Private/Frontend/Partials/Form/Navigation.html
@@ -37,7 +37,7 @@
 													value="{form.pages -> f:count()}"
 													class="btn btn-primary {configuration.captchaCssClass}"
 													data="{
-														sitekey: '{configuration.public_key}{f:if(condition: configuration.lang, then: \'?hl=de\')}',
+														sitekey: '{configuration.public_key}',
 														callback: configuration.invisibleCallback
 													}"
 													onclick="document.getElementById('currentPage').value='{form.pages -> f:count()}'"

--- a/Resources/Private/Frontend/Partials/Formhandler/ButtonInvisible.html
+++ b/Resources/Private/Frontend/Partials/Formhandler/ButtonInvisible.html
@@ -8,7 +8,7 @@
 				<f:form.button
 					class="btn btn-primary {configuration.captchaCssClass}"
 					data="{
-						sitekey: '{configuration.public_key}{f:if(condition: configuration.lang, then: \'?hl=de\')}',
+						sitekey: '{configuration.public_key}',
 						callback: configuration.invisibleCallback
 					}"
 				>###LLL:submit###</f:form.button>

--- a/Resources/Private/Frontend/Partials/Recaptcha.html
+++ b/Resources/Private/Frontend/Partials/Recaptcha.html
@@ -29,7 +29,7 @@
 						value="1"
 						additionalAttributes="{formvh:translateElementProperty(element: element, property: 'fluidAdditionalAttributes')}"
 					/>
-					<div class="g-recaptcha" data-sitekey="{configuration.public_key}{f:if(condition: configuration.lang, then: '?hl=de')}"></div>
+					<div class="g-recaptcha" data-sitekey="{configuration.public_key}"></div>
 				</f:then>
 				<f:else>
 					<div class="recaptcha-development-mode">


### PR DESCRIPTION
reCaptcha wasn't rendered with error msg "ERROR for site owner: Invalid site key".
?hl=de GET Parameter was append to the public key inside data-sitekey, instead of the reCaptcha api.js call.