### PR TITLE
Replace file_get_contents with RequestFactory Request

### DIFF
--- a/Classes/Services/CaptchaService.php
+++ b/Classes/Services/CaptchaService.php
@@ -35,7 +35,7 @@ class CaptchaService
     protected ContentObjectRenderer $contentRenderer;
 
     /** @var RequestFactoryInterface */
-    private $requestFactory;
+    protected $requestFactory;
 
     protected array $configuration = [];
 

--- a/Classes/Services/CaptchaService.php
+++ b/Classes/Services/CaptchaService.php
@@ -34,8 +34,7 @@ class CaptchaService
 
     protected ContentObjectRenderer $contentRenderer;
 
-    /** @var RequestFactoryInterface */
-    protected $requestFactory;
+    protected RequestFactoryInterface $requestFactory;
 
     protected array $configuration = [];
 


### PR DESCRIPTION
file_get_contents can lead to wrong handling for proxies on servers.
Therefore using the TYPO3 ReqeustFactory is a way to handle such requests.