### PR TITLE
[BUGFIX] Prevent guzzle rewind error

### DIFF
--- a/Classes/Services/CaptchaService.php
+++ b/Classes/Services/CaptchaService.php
@@ -214,6 +214,6 @@ class CaptchaService
         $params = GeneralUtility::implodeArrayForUrl('', $data);
         $response = $this->requestFactory->request($this->configuration['verify_server'] . '?' . $params, 'POST');
 
-        return $response->getBody()->getContents() ? json_decode($response->getBody()->getContents(), true) : [];
+        return $response->getBody()->__toString() ? json_decode($response->getBody()->__toString(), true) : [];
     }
 }


### PR DESCRIPTION
Using "__toString" instead of "getContents" as the latter does not rewind the stream and can lead to empty respones. See https://github.com/8p/EightPointsGuzzleBundle/issues/48#issuecomment-266306931

Tested with TYPO3 11.5.19 and PHP 8.0