### PR TITLE
Exclude recaptcha JS from any kind of processing

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -79,7 +79,11 @@ plugin.tx_form.settings.yamlConfigurations.1974 = EXT:recaptcha/Configuration/Ya
 plugin.tx_form.view.partialRootPaths.1974 = EXT:recaptcha/Resources/Private/Frontend/Partials/
 
 page.includeJSFooterlibs.recaptcha = {$plugin.tx_recaptcha.api_server}{$plugin.tx_recaptcha.lang}
-page.includeJSFooterlibs.recaptcha.external = 1
+page.includeJSFooterlibs.recaptcha {
+    external = 1
+    disableCompression = 1
+    excludeFromConcatenation = 1
+}
 
 # only included if invisible captcha should be rendered
 page.jsInline.1508480348 = TEXT


### PR DESCRIPTION
As mentioned in https://github.com/evoWeb/recaptcha/issues/64