### PR TITLE
Bugfix CaptchaService - broken recaptcha validation response params

### DIFF
--- a/Classes/Services/CaptchaService.php
+++ b/Classes/Services/CaptchaService.php
@@ -158,7 +158,7 @@ class CaptchaService
 
         $request = [
             'secret' => $this->configuration['private_key'] ?? '',
-            'response' => trim($value ?? $this->getRequest()->getParsedBody()['g-recaptcha-response'] ?? ''),
+            'response' => trim($value ? ($this->getRequest()->getParsedBody()['g-recaptcha-response'] ?? '') : ''),
             'remoteip' => GeneralUtility::getIndpEnv('REMOTE_ADDR'),
         ];
 


### PR DESCRIPTION
If the recapcha checkbox is selected, the script no longer sends the 'g-recaptcha-response', but the value of the recaptcha checkbox, which is 1. The complete recaptcha no longer works without this bugfix!