### PR TITLE
Add CSP settings automatically

### DIFF
--- a/Configuration/ContentSecurityPolicies.php
+++ b/Configuration/ContentSecurityPolicies.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Directive;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Mutation;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\MutationCollection;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\MutationMode;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Scope;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\SourceScheme;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\UriValue;
+use TYPO3\CMS\Core\Type\Map;
+
+return Map::fromEntries([
+    Scope::frontend(),
+    new MutationCollection(
+        new Mutation(
+            MutationMode::Extend,
+            Directive::FrameSrc,
+            SourceScheme::data,
+            new UriValue('https://www.google.com/recaptcha/'),
+            new UriValue('https://recaptcha.google.com/recaptcha/'),
+        ),
+        new Mutation(
+            MutationMode::Extend,
+            Directive::ScriptSrc,
+            SourceScheme::data,
+            new UriValue('https://www.google.com/recaptcha/'),
+            new UriValue('https://www.gstatic.com/recaptcha/'),
+        ),
+    ),
+]);

--- a/Documentation/ContentSecurityPolicy/Index.rst
+++ b/Documentation/ContentSecurityPolicy/Index.rst
@@ -9,32 +9,7 @@ Content Security Policy
 Reason
 ======
 
-Since TYPO3 12 handling of content security policies are introduced. If this
-feature is active, the recaptcha javascript can not be loaded without additional
-configuration.
-
-CSP Configuration
-=================
-
-To get the recaptcha working with csp feature active, it's necessary to add an
-extending mutation to the site configuration in a csp.yaml named file.
-
-..  code-block:: yaml
-    :caption: project_root/config/sites/main/csp.yaml
-
-    inheritDefault: true
-    mutations:
-      - mode: extend
-        directive: 'frame-src'
-        sources:
-          - 'https://www.google.com/recaptcha/'
-          - 'https://recaptcha.google.com/recaptcha/'
-
-      - mode: extend
-        directive: 'script-src'
-        sources:
-          - 'https://www.google.com/recaptcha/'
-          - 'https://www.gstatic.com/recaptcha/'
+Since TYPO3 12 handling of content security policies are introduced. Extension adds required policies automatically.
 
 Template modifications
 ======================


### PR DESCRIPTION
It would be wise not to require user to add CSP settings for extension manually. Extension can add required entries to policy itself.